### PR TITLE
 ♻️ remove unnecessary promise use in Hook Manager

### DIFF
--- a/lib/hook-manager.js
+++ b/lib/hook-manager.js
@@ -18,7 +18,7 @@ class HookManager {
 		if (this.hooks[name]) {
 			const error = new Error(`Hook ${name} is already registered`);
 			error.code = 'EHOOKEXISTS';
-			return Promise.reject(error);
+			throw error;
 		}
 
 		this.hooks[name] = {
@@ -27,17 +27,16 @@ class HookManager {
 			sync
 		};
 
-		return Promise.resolve();
+		return true;
 	}
 
 	generateHookRegisterer(caller = 'default') {
 		return (action, fn) => {
 			if (!this.hooks[action]) {
-				return Promise.reject(noHookError(action));
+				throw noHookError(action);
 			}
 
 			this.hooks[action].hooks.push(new Hook(fn, caller));
-			return Promise.resolve();
 		};
 	}
 


### PR DESCRIPTION
These methods of the HookManager are completely static and don't depend in any way on Promises, so there's no reason for us to use them